### PR TITLE
🔧 Fix CSS Conflicts in Referral Page - Balance Display Issue

### DIFF
--- a/public/referral.html
+++ b/public/referral.html
@@ -98,15 +98,15 @@
             transition: all 0.2s ease;
         }
         .copy-button:active {
-        }
-        
-
             transform: scale(0.95);
         }
         .referral-stats {
             background: linear-gradient(135deg, #4f46e5 0%, #6366f1 100%);
             border-radius: 12px;
             color: white;
+            min-height: 120px;
+            display: block !important;
+            visibility: visible !important;
         }
         .tab-button {
             transition: all 0.2s ease;
@@ -161,6 +161,13 @@
         }
         .show {
             display: block;
+        }
+        
+        /* Debug styles to ensure balance elements are visible */
+        #availableBalance, #totalEarned, #referralsCount, #pendingAmount {
+            display: block !important;
+            visibility: visible !important;
+            color: white !important;
         }
         .dot {
             height: 8px;


### PR DESCRIPTION
✅ Identified CSS Issues:
- Broken CSS rule in .copy-button:active causing parsing errors
- Orphaned transform: scale(0.95); rule not properly closed
- CSS parsing issues affecting entire stylesheet

✅ Fixed CSS Problems:
- Fixed broken .copy-button:active CSS rule
- Properly closed orphaned transform rule
- Added debugging styles to ensure balance elements are visible

✅ Enhanced Visibility:
- Added min-height to referral-stats container
- Added specific debugging styles for balance elements
- Ensured white color for balance text

🔧 Updated Files:
- public/referral.html: Fixed CSS conflicts and added debugging styles

✅ Status: Balance section should now be visible and properly styled