### PR TITLE
Fix EADDRINUSE: let Express own the port; bot no longer binds a port

### DIFF
--- a/server.js
+++ b/server.js
@@ -136,11 +136,10 @@ if (SKIP_TELEGRAM) {
     console.log('⚠️  Telegram bot initialization skipped (SKIP_TELEGRAM=1)');
 } else {
     try {
+        // Initialize bot without creating its own HTTP server.
+        // Express will handle incoming webhook POSTs on WEBHOOK_PATH.
         bot = new TelegramBot(TELEGRAM_BOT_TOKEN, {
-            polling: false, // Disable polling since we're using webhooks
-            webHook: {
-                port: process.env.PORT || 8080
-            }
+            polling: false
         });
         console.log('✅ Telegram bot initialized successfully');
     } catch (error) {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Remove bot's HTTP server configuration to fix EADDRINUSE error

- Let Express handle webhook requests exclusively


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["TelegramBot with webHook port"] -- "Remove" --> B["TelegramBot polling: false only"]
  B -- "Prevents" --> C["EADDRINUSE Error"]
  D["Express Server"] -- "Handles" --> E["Webhook Requests"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server.js</strong><dd><code>Remove bot HTTP server configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server.js

<ul><li>Remove <code>webHook.port</code> configuration from TelegramBot initialization<br> <li> Add comment explaining Express handles webhook POSTs<br> <li> Keep <code>polling: false</code> to maintain webhook mode</ul>


</details>


  </td>
  <td><a href="https://github.com/Leejoneske/Tg-Star-Store/pull/61/files#diff-a4c65ede64197e1a112899a68bf994485b889c4b143198bac4af53425b38406f">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

