### PR TITLE
Fix double webhook path in URL construction

### DIFF
--- a/server.js
+++ b/server.js
@@ -157,10 +157,17 @@ async function setupWebhook() {
         return;
     }
     try {
-        // Construct the full webhook URL properly
-        const fullWebhookUrl = WEBHOOK_URL.endsWith('/') 
-            ? `${WEBHOOK_URL.slice(0, -1)}${WEBHOOK_PATH}`
-            : `${WEBHOOK_URL}${WEBHOOK_PATH}`;
+        // Construct the full webhook URL properly - avoid double /webhook/
+        let fullWebhookUrl;
+        if (WEBHOOK_URL.includes('/webhook/')) {
+            // If WEBHOOK_URL already contains /webhook/, use it as-is
+            fullWebhookUrl = WEBHOOK_URL;
+        } else {
+            // Otherwise, append the webhook path
+            fullWebhookUrl = WEBHOOK_URL.endsWith('/') 
+                ? `${WEBHOOK_URL.slice(0, -1)}${WEBHOOK_PATH}`
+                : `${WEBHOOK_URL}${WEBHOOK_PATH}`;
+        }
         await bot.setWebHook(fullWebhookUrl, {
             secret_token: TELEGRAM_WEBHOOK_SECRET || undefined
         });


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix double `/webhook/` path in URL construction

- Add logic to detect existing webhook path in URL

- Prevent duplicate path segments in webhook setup


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["WEBHOOK_URL"] --> B["Check if contains /webhook/"]
  B --> C["Already contains path?"]
  C -->|Yes| D["Use URL as-is"]
  C -->|No| E["Append WEBHOOK_PATH"]
  D --> F["Final webhook URL"]
  E --> F["Final webhook URL"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server.js</strong><dd><code>Fix webhook URL path duplication logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server.js

<ul><li>Replace simple URL concatenation with conditional logic<br> <li> Check if <code>WEBHOOK_URL</code> already contains <code>/webhook/</code> path<br> <li> Prevent duplicate webhook path segments in URL construction</ul>


</details>


  </td>
  <td><a href="https://github.com/Leejoneske/Tg-Star-Store/pull/66/files#diff-a4c65ede64197e1a112899a68bf994485b889c4b143198bac4af53425b38406f">+11/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

