### PR TITLE
Say hello

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2938,7 +2938,7 @@ async function handlePurchase(item) {
                     <div class="flex justify-center">
                         <div class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center">
                             <svg class="w-12 h-12 text-red-500" fill="currentColor" viewBox="0 0 20 20">
-                                <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/>
+                                <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0 16 0zm-7 4a1 1 0 11-2 0 1 1 0 0 12 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/>
                             </svg>
                         </div>
                     </div>


### PR DESCRIPTION
Fix malformed SVG path data in `index.html` to resolve an "Unexpected identifier" JavaScript syntax error.

The browser was failing to parse the SVG path due to missing spaces between coordinate values (e.g., `0116` instead of `0 16`), which led to a JavaScript syntax error preventing the page from loading correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-78fb79c7-1472-4199-8554-e4483cc3bd65">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-78fb79c7-1472-4199-8554-e4483cc3bd65">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

