### PR TITLE
Fix bot.sendDocument missing method in development stub

### DIFF
--- a/server.js
+++ b/server.js
@@ -19,6 +19,10 @@ if (process.env.BOT_TOKEN) {
   bot = {
     setWebHook: async () => Promise.resolve(),
     sendMessage: async () => Promise.resolve({}),
+    sendDocument: async () => Promise.resolve({}),
+    editMessageText: async () => Promise.resolve({}),
+    editMessageReplyMarkup: async () => Promise.resolve({}),
+    answerCallbackQuery: async () => Promise.resolve({}),
     onText: () => {},
     on: () => {},
     processUpdate: () => {}


### PR DESCRIPTION
- Added sendDocument method to bot stub for local/development environment
- Added editMessageText, editMessageReplyMarkup, and answerCallbackQuery methods
- Fixes 'bot.sendDocument is not a function' error in export transactions
- Export functionality now works in both production and development environments