### PR TITLE
Fix: remove public subdirectories from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -32,10 +32,6 @@ LICENSE
 yarn.lock
 pnpm-lock.yaml
 .pnpm-store
-public/blog
-public/errors
-public/how-to-withdraw-telegram-stars
-public/knowledge-base
 .git
 .github
 .gitlab-ci.yml


### PR DESCRIPTION
The .dockerignore file was excluding:
- public/blog
- public/errors
- public/how-to-withdraw-telegram-stars
- public/knowledge-base

This prevented these critical directories from being included in the Docker build, causing ENOENT errors in production at /app/public/*.

These directories must be deployed for the app to function properly.