### PR TITLE
fix: relax duplicate buy-order blocking and add silent admin replay alerts

### DIFF
--- a/server.js
+++ b/server.js
@@ -4241,33 +4241,63 @@ async function processOrderCreationInternal(req, res, telegramId, username, star
             }
         }
 
-        // Check for recent duplicate orders with timeout protection
-        console.log(`[${timestamp}] VALIDATION: Checking duplicate orders (with timeout protection)...`);
+        // Check for likely duplicate replay orders with timeout protection.
+        // Important: do NOT block legitimate back-to-back orders from the same user.
+        console.log(`[${timestamp}] VALIDATION: Checking duplicate replay orders (with timeout protection)...`);
         let recentOrder = null;
+        const duplicateWindowMs = 15000;
+        const duplicateSignatureQuery = {
+            telegramId,
+            walletAddress,
+            isPremium: Boolean(isPremium),
+            status: { $in: ['pending', 'processing'] },
+            dateCreated: { $gte: new Date(Date.now() - duplicateWindowMs) }
+        };
+
+        if (isPremium) {
+            duplicateSignatureQuery.premiumDuration = premiumDuration;
+        } else {
+            duplicateSignatureQuery.stars = Number(stars);
+        }
+
+        // If transaction hash exists, require same hash for duplicate replay detection.
+        if (transactionHash) {
+            duplicateSignatureQuery.transactionHash = transactionHash;
+        }
+
         try {
             recentOrder = await Promise.race([
-                BuyOrder.findOne({
-                    telegramId,
-                    dateCreated: { $gte: new Date(Date.now() - 60000) },
-                    status: { $in: ['pending', 'processing'] }
-                }),
+                BuyOrder.findOne(duplicateSignatureQuery),
                 new Promise((resolve, reject) => 
                     setTimeout(() => reject(new Error('Duplicate order check timeout')), 5000)
                 )
             ]);
-            console.log(`[${timestamp}] VALIDATION: Duplicate order check complete. found=${!!recentOrder}`);
+            console.log(`[${timestamp}] VALIDATION: Duplicate replay check complete. found=${!!recentOrder}`);
         } catch (queryErr) {
-            console.error(`[${timestamp}] VALIDATION ERROR: Duplicate order query failed | Error: ${queryErr.message}`);
+            console.error(`[${timestamp}] VALIDATION ERROR: Duplicate replay query failed | Error: ${queryErr.message}`);
             // Don't fail the order - just log and continue (treat as if no recent order)
             recentOrder = null;
         }
         
         if (recentOrder) {
             processingRequests.delete(requestKey);
-            const err = new Error('Please wait before placing another order');
+            await sendSilentAdminErrorReport('ORDER_DUPLICATE_REPLAY_BLOCKED', {
+                telegramId,
+                username,
+                walletAddress,
+                stars: isPremium ? null : Number(stars),
+                premiumDuration: isPremium ? premiumDuration : null,
+                transactionHash: transactionHash || null,
+                duplicateOrderId: recentOrder.id,
+                duplicateOrderCreatedAt: recentOrder.dateCreated
+            }, {
+                message: 'Duplicate replay order blocked by signature check',
+                duplicateWindowMs
+            });
+            const err = new Error('Duplicate order detected. Please wait a few seconds and try again.');
             err.isValidationError = true;
             err.statusCode = 400;
-            err.responseBody = { error: 'Please wait before placing another order' };
+            err.responseBody = { error: 'Duplicate order detected. Please wait a few seconds and try again.' };
             throw err;
         }
 


### PR DESCRIPTION
### Motivation
- Fix a bug where near-simultaneous buy attempts by the same user caused one order to be blocked while payment still went through and no admin diagnostics were emitted. 
- Make duplicate protection stricter for true replayed submissions while allowing legitimate back-to-back purchases. 
- Ensure admins receive silent reports when a replay-based block occurs so failures are visible for investigation. 
- Note: this environment had no remote configured so pulling from `main` was not possible here.

### Description
- Replace the coarse recent-order check with a tighter “replay signature” check in `processOrderCreationInternal` that matches `telegramId`, `walletAddress`, product-specific fields (`premiumDuration` or `stars`) and a short time window (15s) when detecting likely replayed submissions. 
- Include `transactionHash` in the duplicate signature when present so hash-backed transactions are handled correctly. 
- Emit a silent admin diagnostic via `sendSilentAdminErrorReport` when a replay is blocked, and update the user-facing error to `Duplicate order detected. Please wait a few seconds and try again.`. 
- Keep previous protections for explicit transaction duplicates (same `transactionHash` within 10 minutes) and preserve timing/timeout safeguards.

### Testing
- Performed a syntax-only check with `node --check server.js`, which passed. 
- Reviewed the modified diff around the `/api/orders/create` validation path and confirmed the new signature-based duplicate query uses the tighter 15s window and conditional fields. 
- Verified the change triggers `sendSilentAdminErrorReport` on replay detection (static code review of the new branching and logging).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d34605d3083269a4f5b7bb38dc170)