### PR TITLE
Update pricing, add duplicate-replay protection, and raise referral thresholds

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -1226,9 +1226,9 @@
                             <div style="background: #f9f9f9; border-radius: 12px; padding: 14px 16px; display: flex; justify-content: space-between; align-items: center; transition: background 0.2s;" class="package-option stars-package" onmouseover="this.style.background='#f0f0f0'" onmouseout="this.style.background='#f9f9f9'">
                                 <div style="flex: 1;">
                                     <div style="font-size: 16px; font-weight: 600; color: #000;">15 Stars</div>
-                                    <div style="font-size: 13px; color: #666; margin-top: 2px;">0.35 USDT</div>
+                                    <div style="font-size: 13px; color: #666; margin-top: 2px;">0.29 USDT</div>
                                 </div>
-                                <button class="btn-primary" style="font-size: 13px; padding: 8px 14px; white-space: nowrap; margin-left: 12px;" data-translate="buygift" data-item='{"stars": 15, "isPremium": false, "amount": "0.35"}'>
+                                <button class="btn-primary" style="font-size: 13px; padding: 8px 14px; white-space: nowrap; margin-left: 12px;" data-translate="buygift" data-item='{"stars": 15, "isPremium": false, "amount": "0.29"}'>
                                     <span>Buy</span>
                                 </button>
                             </div>
@@ -1236,9 +1236,9 @@
                             <div style="background: #f9f9f9; border-radius: 12px; padding: 14px 16px; display: flex; justify-content: space-between; align-items: center; transition: background 0.2s;" class="package-option stars-package" onmouseover="this.style.background='#f0f0f0'" onmouseout="this.style.background='#f9f9f9'">
                                 <div style="flex: 1;">
                                     <div style="font-size: 16px; font-weight: 600; color: #000;">25 Stars</div>
-                                    <div style="font-size: 13px; color: #666; margin-top: 2px;">0.60 USDT</div>
+                                    <div style="font-size: 13px; color: #666; margin-top: 2px;">0.45 USDT</div>
                                 </div>
-                                <button class="btn-primary" style="font-size: 13px; padding: 8px 14px; white-space: nowrap; margin-left: 12px;" data-translate="buygift" data-item='{"stars": 25, "isPremium": false, "amount": "0.60"}'>
+                                <button class="btn-primary" style="font-size: 13px; padding: 8px 14px; white-space: nowrap; margin-left: 12px;" data-translate="buygift" data-item='{"stars": 25, "isPremium": false, "amount": "0.45"}'>
                                     <span>Buy</span>
                                 </button>
                             </div>
@@ -1246,9 +1246,9 @@
                             <div style="background: #f9f9f9; border-radius: 12px; padding: 14px 16px; display: flex; justify-content: space-between; align-items: center; transition: background 0.2s;" class="package-option stars-package" onmouseover="this.style.background='#f0f0f0'" onmouseout="this.style.background='#f9f9f9'" data-stars="50">
                                 <div style="flex: 1;">
                                     <div style="font-size: 16px; font-weight: 600; color: #000;">50 Stars</div>
-                                    <div style="font-size: 13px; color: #666; margin-top: 2px;">1.00 USDT</div>
+                                    <div style="font-size: 13px; color: #666; margin-top: 2px;">0.90 USDT</div>
                                 </div>
-                                <button class="btn-primary" style="font-size: 13px; padding: 8px 14px; white-space: nowrap; margin-left: 12px;" data-translate="buyNow" data-item='{"stars": 50, "isPremium": false, "amount": "1.00"}'>
+                                <button class="btn-primary" style="font-size: 13px; padding: 8px 14px; white-space: nowrap; margin-left: 12px;" data-translate="buyNow" data-item='{"stars": 50, "isPremium": false, "amount": "0.90"}'>
                                     <span>Buy</span>
                                 </button>
                             </div>
@@ -1258,9 +1258,9 @@
                                 <div style="background: #f9f9f9; border-radius: 12px; padding: 14px 16px; display: flex; justify-content: space-between; align-items: center; transition: background 0.2s;" class="package-option stars-package" onmouseover="this.style.background='#f0f0f0'" onmouseout="this.style.background='#f9f9f9'" data-stars="100">
                                     <div style="flex: 1;">
                                         <div style="font-size: 16px; font-weight: 600; color: #000;">100 Stars</div>
-                                        <div style="font-size: 13px; color: #666; margin-top: 2px;">2.00 USDT</div>
+                                        <div style="font-size: 13px; color: #666; margin-top: 2px;">1.79 USDT</div>
                                     </div>
-                                    <button class="btn-primary" style="font-size: 13px; padding: 8px 14px; white-space: nowrap; margin-left: 12px;" data-translate="buyNow" data-item='{"stars": 100, "isPremium": false, "amount": "2.00"}'>
+                                    <button class="btn-primary" style="font-size: 13px; padding: 8px 14px; white-space: nowrap; margin-left: 12px;" data-translate="buyNow" data-item='{"stars": 100, "isPremium": false, "amount": "1.79"}'>
                                         <span>Buy</span>
                                     </button>
                                 </div>
@@ -1268,19 +1268,19 @@
                                 <div style="background: #f9f9f9; border-radius: 12px; padding: 14px 16px; display: flex; justify-content: space-between; align-items: center; transition: background 0.2s;" class="package-option stars-package" onmouseover="this.style.background='#f0f0f0'" onmouseout="this.style.background='#f9f9f9'" data-stars="500">
                                     <div style="flex: 1;">
                                         <div style="font-size: 16px; font-weight: 600; color: #000;">500 Stars</div>
-                                        <div style="font-size: 13px; color: #666; margin-top: 2px;">10.00 USDT</div>
+                                        <div style="font-size: 13px; color: #666; margin-top: 2px;">8.95 USDT</div>
                                     </div>
-                                    <button class="btn-primary" style="font-size: 13px; padding: 8px 14px; white-space: nowrap; margin-left: 12px;" data-translate="buyNow" data-item='{"stars": 500, "isPremium": false, "amount": "10.00"}'>
+                                    <button class="btn-primary" style="font-size: 13px; padding: 8px 14px; white-space: nowrap; margin-left: 12px;" data-translate="buyNow" data-item='{"stars": 500, "isPremium": false, "amount": "8.95"}'>
                                         <span>Buy</span>
                                     </button>
                                 </div>
                                 <!-- Package 6: 1000 Stars (hidden) -->
-                            <div style="background: #f9f9f9; border-radius: 12px; padding: 14px 16px; display: flex; justify-content: space-between; align-items: center; transition: background 0.2s;" class="package-option stars-package" data-best="true" onmouseover="this.style.background='#f0f0f0'" onmouseout="this.style.background='#f9f9f9'" data-stars="1000">
+                            <div style="background: #f9f9f9; border-radius: 12px; padding: 14px 16px; display: flex; justify-content: space-between; align-items: center; transition: background 0.2s;" class="package-option stars-package" onmouseover="this.style.background='#f0f0f0'" onmouseout="this.style.background='#f9f9f9'" data-stars="1000">
                                     <div style="flex: 1;">
-                                    <div style="font-size: 16px; font-weight: 600; color: #000;">1000 Stars <span class="best-badge">Best value</span></div>
-                                        <div style="font-size: 13px; color: #666; margin-top: 2px;">20.00 USDT</div>
+                                    <div style="font-size: 16px; font-weight: 600; color: #000;">1000 Stars</div>
+                                        <div style="font-size: 13px; color: #666; margin-top: 2px;">17.90 USDT</div>
                                     </div>
-                                    <button class="btn-primary" style="font-size: 13px; padding: 8px 14px; white-space: nowrap; margin-left: 12px;" data-translate="buyNow" data-item='{"stars": 1000, "isPremium": false, "amount": "20.00"}'>
+                                    <button class="btn-primary" style="font-size: 13px; padding: 8px 14px; white-space: nowrap; margin-left: 12px;" data-translate="buyNow" data-item='{"stars": 1000, "isPremium": false, "amount": "17.90"}'>
                                         <span>Buy</span>
                                     </button>
                                 </div>
@@ -1333,7 +1333,7 @@
                                         <div style="font-size: 18px; font-weight: 700; color: #000; margin-bottom: 4px;" data-translate="3monthsPremium">3 Months Premium</div>
                                         <div style="font-size: 13px; color: #666;" data-translate="3monthsDesc">Unlock premium features for 3 months</div>
                                     </div>
-                                    <div style="font-size: 16px; font-weight: 600; color: #007AFF;" class="package-price">19.31 USDT</div>
+                                    <div style="font-size: 16px; font-weight: 600; color: #007AFF;" class="package-price">12.99 USDT</div>
                                 </div>
                                 <div style="display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 12px;">
                                     <div style="display: flex; align-items: center; gap: 6px; font-size: 12px; color: #666; background: white; padding: 4px 8px; border-radius: 6px;">
@@ -1355,7 +1355,7 @@
                                         <span>Exclusive Stickers</span>
                                     </div>
                                 </div>
-                                <button class="btn-primary" style="font-size: 13px; padding: 10px 16px;" data-translate="buyNow" data-item='{"stars": null, "isPremium": true, "premiumDuration": 3, "amount": "19.31"}'>
+                                <button class="btn-primary" style="font-size: 13px; padding: 10px 16px;" data-translate="buyNow" data-item='{"stars": null, "isPremium": true, "premiumDuration": 3, "amount": "12.99"}'>
                                     <svg style="width: 14px; height: 14px;" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
                                     </svg>
@@ -1368,7 +1368,7 @@
                                         <div style="font-size: 18px; font-weight: 700; color: #000; margin-bottom: 4px;" data-translate="6monthsPremium">6 Months Premium</div>
                                         <div style="font-size: 13px; color: #666;" data-translate="6monthsDesc">Unlock premium features for 6 months</div>
                                     </div>
-                                    <div style="font-size: 16px; font-weight: 600; color: #007AFF;" class="package-price">26.25 USDT</div>
+                                    <div style="font-size: 16px; font-weight: 600; color: #007AFF;" class="package-price">16.99 USDT</div>
                                 </div>
                                 <div style="display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 12px;">
                                     <div style="display: flex; align-items: center; gap: 6px; font-size: 12px; color: #666; background: white; padding: 4px 8px; border-radius: 6px;">
@@ -1396,7 +1396,7 @@
                                         <span>Voice-to-Text</span>
                                     </div>
                                 </div>
-                                <button class="btn-primary" style="font-size: 13px; padding: 10px 16px;" data-translate="buyNow" data-item='{"stars": null, "isPremium": true, "premiumDuration": 6, "amount": "26.25"}'>
+                                <button class="btn-primary" style="font-size: 13px; padding: 10px 16px;" data-translate="buyNow" data-item='{"stars": null, "isPremium": true, "premiumDuration": 6, "amount": "16.99"}'>
                                     <svg style="width: 14px; height: 14px;" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
                                     </svg>
@@ -1409,7 +1409,7 @@
                                         <div style="font-size: 18px; font-weight: 700; color: #000; margin-bottom: 4px;" data-translate="12monthsPremium">12 Months Premium <span class="best-badge">Best value</span></div>
                                         <div style="font-size: 13px; color: #666;" data-translate="12monthsDesc">Unlock premium features for 12 months</div>
                                     </div>
-                                    <div style="font-size: 16px; font-weight: 600; color: #007AFF;" class="package-price">44.79 USDT</div>
+                                    <div style="font-size: 16px; font-weight: 600; color: #007AFF;" class="package-price">29.99 USDT</div>
                                 </div>
                                 <div style="display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 12px;">
                                     <div style="display: flex; align-items: center; gap: 6px; font-size: 12px; color: #666; background: white; padding: 4px 8px; border-radius: 6px;">
@@ -1449,7 +1449,7 @@
                                         <span>Premium Reactions</span>
                                     </div>
                                 </div>
-                                <button class="btn-primary" style="font-size: 13px; padding: 10px 16px;" data-translate="buyNow" data-item='{"stars": null, "isPremium": true, "premiumDuration": 12, "amount": "44.79"}'>
+                                <button class="btn-primary" style="font-size: 13px; padding: 10px 16px;" data-translate="buyNow" data-item='{"stars": null, "isPremium": true, "premiumDuration": 12, "amount": "29.99"}'>
                                     <svg style="width: 14px; height: 14px;" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
                                     </svg>
@@ -3540,10 +3540,10 @@ function showEstimatedPrices(recipientsCount) {
     // Use actual server pricing for estimates (from server.js priceMap)
     const quantity = Math.max(1, recipientsCount);
     const basePrices = {
-        50: 1.00,    // Server: 50: 1
-        100: 2.00,   // Server: 100: 2  
-        500: 10.00,  // Server: 500: 10
-        1000: 20.00  // Server: 1000: 20
+        50: 0.90,    // Server: 50: 0.9
+        100: 1.79,   // Server: 100: 1.79  
+        500: 8.95,  // Server: 500: 8.95
+        1000: 17.90  // Server: 1000: 17.9
     };
     
     // For stars, price doesn't multiply by recipients (stars are distributed)
@@ -3552,9 +3552,9 @@ function showEstimatedPrices(recipientsCount) {
         100: basePrices[100].toFixed(2), 
         500: basePrices[500].toFixed(2),
         1000: basePrices[1000].toFixed(2),
-        premium_3: (19.31 * quantity).toFixed(2),
-        premium_6: (26.25 * quantity).toFixed(2),
-        premium_12: (44.79 * quantity).toFixed(2)
+        premium_3: (12.99 * quantity).toFixed(2),
+        premium_6: (16.99 * quantity).toFixed(2),
+        premium_12: (29.99 * quantity).toFixed(2)
     };
 
     // Update stars packages with estimates

--- a/public/index.html
+++ b/public/index.html
@@ -1226,9 +1226,9 @@
                             <div style="background: #f9f9f9; border-radius: 12px; padding: 14px 16px; display: flex; justify-content: space-between; align-items: center; transition: background 0.2s;" class="package-option stars-package" onmouseover="this.style.background='#f0f0f0'" onmouseout="this.style.background='#f9f9f9'">
                                 <div style="flex: 1;">
                                     <div style="font-size: 16px; font-weight: 600; color: #000;">15 Stars</div>
-                                    <div style="font-size: 13px; color: #666; margin-top: 2px;">0.35 USDT</div>
+                                    <div style="font-size: 13px; color: #666; margin-top: 2px;">0.29 USDT</div>
                                 </div>
-                                <button class="btn-primary" style="font-size: 13px; padding: 8px 14px; white-space: nowrap; margin-left: 12px;" data-translate="buygift" data-item='{"stars": 15, "isPremium": false, "amount": "0.35"}'>
+                                <button class="btn-primary" style="font-size: 13px; padding: 8px 14px; white-space: nowrap; margin-left: 12px;" data-translate="buygift" data-item='{"stars": 15, "isPremium": false, "amount": "0.29"}'>
                                     <span>Buy</span>
                                 </button>
                             </div>
@@ -1236,9 +1236,9 @@
                             <div style="background: #f9f9f9; border-radius: 12px; padding: 14px 16px; display: flex; justify-content: space-between; align-items: center; transition: background 0.2s;" class="package-option stars-package" onmouseover="this.style.background='#f0f0f0'" onmouseout="this.style.background='#f9f9f9'">
                                 <div style="flex: 1;">
                                     <div style="font-size: 16px; font-weight: 600; color: #000;">25 Stars</div>
-                                    <div style="font-size: 13px; color: #666; margin-top: 2px;">0.60 USDT</div>
+                                    <div style="font-size: 13px; color: #666; margin-top: 2px;">0.45 USDT</div>
                                 </div>
-                                <button class="btn-primary" style="font-size: 13px; padding: 8px 14px; white-space: nowrap; margin-left: 12px;" data-translate="buygift" data-item='{"stars": 25, "isPremium": false, "amount": "0.60"}'>
+                                <button class="btn-primary" style="font-size: 13px; padding: 8px 14px; white-space: nowrap; margin-left: 12px;" data-translate="buygift" data-item='{"stars": 25, "isPremium": false, "amount": "0.45"}'>
                                     <span>Buy</span>
                                 </button>
                             </div>
@@ -1246,9 +1246,9 @@
                             <div style="background: #f9f9f9; border-radius: 12px; padding: 14px 16px; display: flex; justify-content: space-between; align-items: center; transition: background 0.2s;" class="package-option stars-package" onmouseover="this.style.background='#f0f0f0'" onmouseout="this.style.background='#f9f9f9'" data-stars="50">
                                 <div style="flex: 1;">
                                     <div style="font-size: 16px; font-weight: 600; color: #000;">50 Stars</div>
-                                    <div style="font-size: 13px; color: #666; margin-top: 2px;">1.00 USDT</div>
+                                    <div style="font-size: 13px; color: #666; margin-top: 2px;">0.90 USDT</div>
                                 </div>
-                                <button class="btn-primary" style="font-size: 13px; padding: 8px 14px; white-space: nowrap; margin-left: 12px;" data-translate="buyNow" data-item='{"stars": 50, "isPremium": false, "amount": "1.00"}'>
+                                <button class="btn-primary" style="font-size: 13px; padding: 8px 14px; white-space: nowrap; margin-left: 12px;" data-translate="buyNow" data-item='{"stars": 50, "isPremium": false, "amount": "0.90"}'>
                                     <span>Buy</span>
                                 </button>
                             </div>
@@ -1258,9 +1258,9 @@
                                 <div style="background: #f9f9f9; border-radius: 12px; padding: 14px 16px; display: flex; justify-content: space-between; align-items: center; transition: background 0.2s;" class="package-option stars-package" onmouseover="this.style.background='#f0f0f0'" onmouseout="this.style.background='#f9f9f9'" data-stars="100">
                                     <div style="flex: 1;">
                                         <div style="font-size: 16px; font-weight: 600; color: #000;">100 Stars</div>
-                                        <div style="font-size: 13px; color: #666; margin-top: 2px;">2.00 USDT</div>
+                                        <div style="font-size: 13px; color: #666; margin-top: 2px;">1.79 USDT</div>
                                     </div>
-                                    <button class="btn-primary" style="font-size: 13px; padding: 8px 14px; white-space: nowrap; margin-left: 12px;" data-translate="buyNow" data-item='{"stars": 100, "isPremium": false, "amount": "2.00"}'>
+                                    <button class="btn-primary" style="font-size: 13px; padding: 8px 14px; white-space: nowrap; margin-left: 12px;" data-translate="buyNow" data-item='{"stars": 100, "isPremium": false, "amount": "1.79"}'>
                                         <span>Buy</span>
                                     </button>
                                 </div>
@@ -1268,19 +1268,19 @@
                                 <div style="background: #f9f9f9; border-radius: 12px; padding: 14px 16px; display: flex; justify-content: space-between; align-items: center; transition: background 0.2s;" class="package-option stars-package" onmouseover="this.style.background='#f0f0f0'" onmouseout="this.style.background='#f9f9f9'" data-stars="500">
                                     <div style="flex: 1;">
                                         <div style="font-size: 16px; font-weight: 600; color: #000;">500 Stars</div>
-                                        <div style="font-size: 13px; color: #666; margin-top: 2px;">10.00 USDT</div>
+                                        <div style="font-size: 13px; color: #666; margin-top: 2px;">8.95 USDT</div>
                                     </div>
-                                    <button class="btn-primary" style="font-size: 13px; padding: 8px 14px; white-space: nowrap; margin-left: 12px;" data-translate="buyNow" data-item='{"stars": 500, "isPremium": false, "amount": "10.00"}'>
+                                    <button class="btn-primary" style="font-size: 13px; padding: 8px 14px; white-space: nowrap; margin-left: 12px;" data-translate="buyNow" data-item='{"stars": 500, "isPremium": false, "amount": "8.95"}'>
                                         <span>Buy</span>
                                     </button>
                                 </div>
                                 <!-- Package 6: 1000 Stars (hidden) -->
-                            <div style="background: #f9f9f9; border-radius: 12px; padding: 14px 16px; display: flex; justify-content: space-between; align-items: center; transition: background 0.2s;" class="package-option stars-package" data-best="true" onmouseover="this.style.background='#f0f0f0'" onmouseout="this.style.background='#f9f9f9'" data-stars="1000">
+                            <div style="background: #f9f9f9; border-radius: 12px; padding: 14px 16px; display: flex; justify-content: space-between; align-items: center; transition: background 0.2s;" class="package-option stars-package" onmouseover="this.style.background='#f0f0f0'" onmouseout="this.style.background='#f9f9f9'" data-stars="1000">
                                     <div style="flex: 1;">
-                                    <div style="font-size: 16px; font-weight: 600; color: #000;">1000 Stars <span class="best-badge">Best value</span></div>
-                                        <div style="font-size: 13px; color: #666; margin-top: 2px;">20.00 USDT</div>
+                                    <div style="font-size: 16px; font-weight: 600; color: #000;">1000 Stars</div>
+                                        <div style="font-size: 13px; color: #666; margin-top: 2px;">17.90 USDT</div>
                                     </div>
-                                    <button class="btn-primary" style="font-size: 13px; padding: 8px 14px; white-space: nowrap; margin-left: 12px;" data-translate="buyNow" data-item='{"stars": 1000, "isPremium": false, "amount": "20.00"}'>
+                                    <button class="btn-primary" style="font-size: 13px; padding: 8px 14px; white-space: nowrap; margin-left: 12px;" data-translate="buyNow" data-item='{"stars": 1000, "isPremium": false, "amount": "17.90"}'>
                                         <span>Buy</span>
                                     </button>
                                 </div>
@@ -1333,7 +1333,7 @@
                                         <div style="font-size: 18px; font-weight: 700; color: #000; margin-bottom: 4px;" data-translate="3monthsPremium">3 Months Premium</div>
                                         <div style="font-size: 13px; color: #666;" data-translate="3monthsDesc">Unlock premium features for 3 months</div>
                                     </div>
-                                    <div style="font-size: 16px; font-weight: 600; color: #007AFF;" class="package-price">19.31 USDT</div>
+                                    <div style="font-size: 16px; font-weight: 600; color: #007AFF;" class="package-price">12.99 USDT</div>
                                 </div>
                                 <div style="display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 12px;">
                                     <div style="display: flex; align-items: center; gap: 6px; font-size: 12px; color: #666; background: white; padding: 4px 8px; border-radius: 6px;">
@@ -1355,7 +1355,7 @@
                                         <span>Exclusive Stickers</span>
                                     </div>
                                 </div>
-                                <button class="btn-primary" style="font-size: 13px; padding: 10px 16px;" data-translate="buyNow" data-item='{"stars": null, "isPremium": true, "premiumDuration": 3, "amount": "19.31"}'>
+                                <button class="btn-primary" style="font-size: 13px; padding: 10px 16px;" data-translate="buyNow" data-item='{"stars": null, "isPremium": true, "premiumDuration": 3, "amount": "12.99"}'>
                                     <svg style="width: 14px; height: 14px;" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
                                     </svg>
@@ -1368,7 +1368,7 @@
                                         <div style="font-size: 18px; font-weight: 700; color: #000; margin-bottom: 4px;" data-translate="6monthsPremium">6 Months Premium</div>
                                         <div style="font-size: 13px; color: #666;" data-translate="6monthsDesc">Unlock premium features for 6 months</div>
                                     </div>
-                                    <div style="font-size: 16px; font-weight: 600; color: #007AFF;" class="package-price">26.25 USDT</div>
+                                    <div style="font-size: 16px; font-weight: 600; color: #007AFF;" class="package-price">16.99 USDT</div>
                                 </div>
                                 <div style="display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 12px;">
                                     <div style="display: flex; align-items: center; gap: 6px; font-size: 12px; color: #666; background: white; padding: 4px 8px; border-radius: 6px;">
@@ -1396,7 +1396,7 @@
                                         <span>Voice-to-Text</span>
                                     </div>
                                 </div>
-                                <button class="btn-primary" style="font-size: 13px; padding: 10px 16px;" data-translate="buyNow" data-item='{"stars": null, "isPremium": true, "premiumDuration": 6, "amount": "26.25"}'>
+                                <button class="btn-primary" style="font-size: 13px; padding: 10px 16px;" data-translate="buyNow" data-item='{"stars": null, "isPremium": true, "premiumDuration": 6, "amount": "16.99"}'>
                                     <svg style="width: 14px; height: 14px;" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
                                     </svg>
@@ -1409,7 +1409,7 @@
                                         <div style="font-size: 18px; font-weight: 700; color: #000; margin-bottom: 4px;" data-translate="12monthsPremium">12 Months Premium <span class="best-badge">Best value</span></div>
                                         <div style="font-size: 13px; color: #666;" data-translate="12monthsDesc">Unlock premium features for 12 months</div>
                                     </div>
-                                    <div style="font-size: 16px; font-weight: 600; color: #007AFF;" class="package-price">44.79 USDT</div>
+                                    <div style="font-size: 16px; font-weight: 600; color: #007AFF;" class="package-price">29.99 USDT</div>
                                 </div>
                                 <div style="display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 12px;">
                                     <div style="display: flex; align-items: center; gap: 6px; font-size: 12px; color: #666; background: white; padding: 4px 8px; border-radius: 6px;">
@@ -1449,7 +1449,7 @@
                                         <span>Premium Reactions</span>
                                     </div>
                                 </div>
-                                <button class="btn-primary" style="font-size: 13px; padding: 10px 16px;" data-translate="buyNow" data-item='{"stars": null, "isPremium": true, "premiumDuration": 12, "amount": "44.79"}'>
+                                <button class="btn-primary" style="font-size: 13px; padding: 10px 16px;" data-translate="buyNow" data-item='{"stars": null, "isPremium": true, "premiumDuration": 12, "amount": "29.99"}'>
                                     <svg style="width: 14px; height: 14px;" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
                                     </svg>
@@ -3540,10 +3540,10 @@ function showEstimatedPrices(recipientsCount) {
     // Use actual server pricing for estimates (from server.js priceMap)
     const quantity = Math.max(1, recipientsCount);
     const basePrices = {
-        50: 1.00,    // Server: 50: 1
-        100: 2.00,   // Server: 100: 2  
-        500: 10.00,  // Server: 500: 10
-        1000: 20.00  // Server: 1000: 20
+        50: 0.90,    // Server: 50: 0.9
+        100: 1.79,   // Server: 100: 1.79  
+        500: 8.95,  // Server: 500: 8.95
+        1000: 17.90  // Server: 1000: 17.9
     };
     
     // For stars, price doesn't multiply by recipients (stars are distributed)
@@ -3552,9 +3552,9 @@ function showEstimatedPrices(recipientsCount) {
         100: basePrices[100].toFixed(2), 
         500: basePrices[500].toFixed(2),
         1000: basePrices[1000].toFixed(2),
-        premium_3: (19.31 * quantity).toFixed(2),
-        premium_6: (26.25 * quantity).toFixed(2),
-        premium_12: (44.79 * quantity).toFixed(2)
+        premium_3: (12.99 * quantity).toFixed(2),
+        premium_6: (16.99 * quantity).toFixed(2),
+        premium_12: (29.99 * quantity).toFixed(2)
     };
 
     // Update stars packages with estimates

--- a/server.js
+++ b/server.js
@@ -3710,8 +3710,8 @@ app.post('/api/quote', requireTelegramAuth, (req, res) => {
         const timestamp = new Date().toISOString();
 
         const priceMap = {
-            regular: { 1000: 20, 500: 10, 100: 2, 50: 1, 25: 0.6, 15: 0.35 },
-            premium: { 3: 19.31, 6: 26.25, 12: 44.79 }
+            regular: { 1000: 17.9, 500: 8.95, 100: 1.79, 50: 0.9, 25: 0.45, 15: 0.29 },
+            premium: { 3: 12.99, 6: 16.99, 12: 29.99 }
         };
 
         if (isPremium) {
@@ -3751,11 +3751,11 @@ app.post('/api/quote', requireTelegramAuth, (req, res) => {
                 quantity 
             });
         } else {
-            // Fallback to linear rate for custom amounts: $0.02 per star
+            // Fallback to linear rate for custom amounts: $0.0179 per star
             // VALIDATE: This should not happen for standard packages, only custom amounts
-            const unitAmount = Number((starsNum * 0.02).toFixed(2));
+            const unitAmount = Number((starsNum * 0.0179).toFixed(2));
             const totalAmount = Number((unitAmount * quantity).toFixed(2));
-            console.warn(`[${timestamp}] QUOTE FALLBACK | Custom: ${starsNum} stars @ $0.02/star x ${quantity} recipient(s) | Unit: ${unitAmount} USDT | Total: ${totalAmount} USDT`);
+            console.warn(`[${timestamp}] QUOTE FALLBACK | Custom: ${starsNum} stars @ $0.0179/star x ${quantity} recipient(s) | Unit: ${unitAmount} USDT | Total: ${totalAmount} USDT`);
             return res.json({ success: true, totalAmount, unitAmount, quantity });
         }
     } catch (error) {
@@ -3775,8 +3775,8 @@ app.get('/api/quote', (req, res) => {
         const quantity = Math.max(1, Number(recipientsCount) || 0);
 
         const priceMap = {
-            regular: { 1000: 20, 500: 10, 100: 2, 50: 1, 25: 0.6, 15: 0.35 },
-            premium: { 3: 19.31, 6: 26.25, 12: 44.79 }
+            regular: { 1000: 17.9, 500: 8.95, 100: 1.79, 50: 0.9, 25: 0.45, 15: 0.29 },
+            premium: { 3: 12.99, 6: 16.99, 12: 29.99 }
         };
 
         if (isPremium) {
@@ -3814,7 +3814,7 @@ app.get('/api/quote', (req, res) => {
             });
         } else {
             // Fallback to linear rate for custom amounts
-            const unitAmount = Number((starsNum * 0.02).toFixed(2));
+            const unitAmount = Number((starsNum * 0.0179).toFixed(2));
             const totalAmount = Number((unitAmount * quantity).toFixed(2));
             return res.json({ success: true, totalAmount, unitAmount, quantity });
         }
@@ -4241,33 +4241,63 @@ async function processOrderCreationInternal(req, res, telegramId, username, star
             }
         }
 
-        // Check for recent duplicate orders with timeout protection
-        console.log(`[${timestamp}] VALIDATION: Checking duplicate orders (with timeout protection)...`);
+        // Check for likely duplicate replay orders with timeout protection.
+        // Important: do NOT block legitimate back-to-back orders from the same user.
+        console.log(`[${timestamp}] VALIDATION: Checking duplicate replay orders (with timeout protection)...`);
         let recentOrder = null;
+        const duplicateWindowMs = 15000;
+        const duplicateSignatureQuery = {
+            telegramId,
+            walletAddress,
+            isPremium: Boolean(isPremium),
+            status: { $in: ['pending', 'processing'] },
+            dateCreated: { $gte: new Date(Date.now() - duplicateWindowMs) }
+        };
+
+        if (isPremium) {
+            duplicateSignatureQuery.premiumDuration = premiumDuration;
+        } else {
+            duplicateSignatureQuery.stars = Number(stars);
+        }
+
+        // If transaction hash exists, require same hash for duplicate replay detection.
+        if (transactionHash) {
+            duplicateSignatureQuery.transactionHash = transactionHash;
+        }
+
         try {
             recentOrder = await Promise.race([
-                BuyOrder.findOne({
-                    telegramId,
-                    dateCreated: { $gte: new Date(Date.now() - 60000) },
-                    status: { $in: ['pending', 'processing'] }
-                }),
+                BuyOrder.findOne(duplicateSignatureQuery),
                 new Promise((resolve, reject) => 
                     setTimeout(() => reject(new Error('Duplicate order check timeout')), 5000)
                 )
             ]);
-            console.log(`[${timestamp}] VALIDATION: Duplicate order check complete. found=${!!recentOrder}`);
+            console.log(`[${timestamp}] VALIDATION: Duplicate replay check complete. found=${!!recentOrder}`);
         } catch (queryErr) {
-            console.error(`[${timestamp}] VALIDATION ERROR: Duplicate order query failed | Error: ${queryErr.message}`);
+            console.error(`[${timestamp}] VALIDATION ERROR: Duplicate replay query failed | Error: ${queryErr.message}`);
             // Don't fail the order - just log and continue (treat as if no recent order)
             recentOrder = null;
         }
         
         if (recentOrder) {
             processingRequests.delete(requestKey);
-            const err = new Error('Please wait before placing another order');
+            await sendSilentAdminErrorReport('ORDER_DUPLICATE_REPLAY_BLOCKED', {
+                telegramId,
+                username,
+                walletAddress,
+                stars: isPremium ? null : Number(stars),
+                premiumDuration: isPremium ? premiumDuration : null,
+                transactionHash: transactionHash || null,
+                duplicateOrderId: recentOrder.id,
+                duplicateOrderCreatedAt: recentOrder.dateCreated
+            }, {
+                message: 'Duplicate replay order blocked by signature check',
+                duplicateWindowMs
+            });
+            const err = new Error('Duplicate order detected. Please wait a few seconds and try again.');
             err.isValidationError = true;
             err.statusCode = 400;
-            err.responseBody = { error: 'Please wait before placing another order' };
+            err.responseBody = { error: 'Duplicate order detected. Please wait a few seconds and try again.' };
             throw err;
         }
 
@@ -4315,8 +4345,8 @@ async function processOrderCreationInternal(req, res, telegramId, username, star
         // Never trust client-submitted amounts - they can be manipulated
         let amount;
         const priceMap = {
-            regular: { 1000: 20, 500: 10, 100: 2, 50: 1, 25: 0.6, 15: 0.35 },
-            premium: { 3: 19.31, 6: 26.25, 12: 44.79 }
+            regular: { 1000: 17.9, 500: 8.95, 100: 1.79, 50: 0.9, 25: 0.45, 15: 0.29 },
+            premium: { 3: 12.99, 6: 16.99, 12: 29.99 }
         };
         
         // Calculate base unit price
@@ -4340,13 +4370,13 @@ async function processOrderCreationInternal(req, res, telegramId, username, star
             }
             isStandardPackage = true;
         } else {
-            // Regular stars: use map if available, otherwise calculate at $0.02/star
+            // Regular stars: use map if available, otherwise calculate at $0.0179/star
             if (priceMap.regular[stars]) {
                 basePrice = priceMap.regular[stars];
                 isStandardPackage = true;
             } else {
-                // Custom amount: use $0.02 per star as base rate
-                basePrice = Number((stars * 0.02).toFixed(4));
+                // Custom amount: use $0.0179 per star as base rate
+                basePrice = Number((stars * 0.0179).toFixed(4));
                 isStandardPackage = false;
             }
         }
@@ -9340,7 +9370,7 @@ async function repairStuckReferrals(userId) {
                 // Check if this referral should be activated
                 const totalStars = tracker.totalBoughtStars + tracker.totalSoldStars;
                 
-                if ((totalStars >= 100 || tracker.premiumActivated) && tracker.status === 'pending') {
+                if ((totalStars >= 200 || tracker.premiumActivated) && tracker.status === 'pending') {
                     // Activate the referral
                     console.log(`[REPAIR] Activating stuck referral ${referral._id} for user ${userId}: ${totalStars} stars`);
                     
@@ -11314,10 +11344,10 @@ async function trackStars(userId, stars, type) {
 
         const totalStars = tracker.totalBoughtStars + tracker.totalSoldStars;
         
-        // NEW REFERRAL (instantActivation=true): activate immediately at 100+ stars
+        // NEW REFERRAL (instantActivation=true): activate immediately at 200+ stars
         // OLD REFERRAL (instantActivation=false): wait for admin confirmation
         // Only valid transactions count: processing or completed (not failed/declined/refunded)
-        if ((totalStars >= 100 || tracker.premiumActivated) && tracker.status === 'pending') {
+        if ((totalStars >= 200 || tracker.premiumActivated) && tracker.status === 'pending') {
             if (tracker.instantActivation === true) {
                 // Instant activation for new referrals
                 await handleReferralActivation(tracker);
@@ -11330,7 +11360,7 @@ async function trackStars(userId, stars, type) {
         }
         
         // Also update the Referral status if it's still pending and conditions are met
-        if (tracker.referral && (totalStars >= 100 || tracker.premiumActivated)) {
+        if (tracker.referral && (totalStars >= 200 || tracker.premiumActivated)) {
             const referral = await Referral.findById(tracker.referral);
             if (referral && referral.status === 'pending' && tracker.instantActivation === true) {
                 referral.status = 'active';
@@ -12823,7 +12853,7 @@ async function handleReferralsCommand(msg) {
             const pendingReferrals = referrals.filter(ref => ref.status === 'pending').length;
             
             let message = `📊 Your Referrals (ALL):\n\nActive: ${activeReferrals}\nPending: ${pendingReferrals}\n\n`;
-            message += 'New referrals activate instantly at 100+ stars!\n\n';
+            message += 'New referrals activate instantly at 200+ stars!\n\n';
             message += `🔗 Your Referral Link:\n${referralLink}`;
             
             const keyboard = {


### PR DESCRIPTION
### Motivation

- Align displayed and server-side prices with new pricing for stars and premium subscriptions and ensure client estimates match server logic.
- Reduce risk of accidental or replay duplicate orders by introducing a short signature-based duplicate detection window.
- Change referral activation requirements to a higher threshold to reflect updated business rules.

### Description

- Updated regular star package prices and premium subscription prices in the front-end HTML (`public/index.html`, `dist/index.html`) including `data-item` amounts and estimated price display logic in `showEstimatedPrices`.
- Updated server-side `priceMap` and per-star fallback rate from `$0.02` to `$0.0179` in `server.js`, and adjusted all server quote/amount calculations to use the new values.
- Implemented duplicate replay protection during order creation by adding a 15s `duplicateWindowMs` query that matches on `telegramId`, `walletAddress`, `isPremium`, `status`, and (when present) `transactionHash`, and added a silent admin error report when a duplicate is blocked.
- Raised referral activation thresholds from 100 to 200 stars across referral repair and tracking logic and updated the user-facing referrals message accordingly.

### Testing

- Ran the automated test suite with `npm test` and all tests passed.
- Performed a CI build with `npm run build` which completed successfully and produced updated front-end artifacts.
- Ran automated API integration tests for `/api/quote` and order-creation duplicate detection scenarios and verified responses reflect the new pricing and duplicate-block behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d34605d3083269a4f5b7bb38dc170)