### PR TITLE
Fix undefined Order model in getTargetUsersByGroup function

### DIFF
--- a/server.js
+++ b/server.js
@@ -20722,7 +20722,7 @@ async function getTargetUsersByGroup(targetGroup) {
 
         case 'buyers_30d':
             // Users who made purchases in past 30 days
-            const buyerIds = await Order.distinct('userId', { createdAt: { $gte: thirtyDaysAgo }, status: 'completed' });
+            const buyerIds = await BuyOrder.distinct('userId', { createdAt: { $gte: thirtyDaysAgo }, status: 'completed' });
             return await User.find({ id: { $in: buyerIds } }, { id: 1, email: 1 });
 
         case 'sellers_30d':
@@ -20732,7 +20732,7 @@ async function getTargetUsersByGroup(targetGroup) {
 
         case 'both_30d':
             // Users who both bought and sold in past 30 days
-            const buyerIds2 = await Order.distinct('userId', { createdAt: { $gte: thirtyDaysAgo }, status: 'completed' });
+            const buyerIds2 = await BuyOrder.distinct('userId', { createdAt: { $gte: thirtyDaysAgo }, status: 'completed' });
             const sellerIds2 = await Withdrawal.distinct('userId', { createdAt: { $gte: thirtyDaysAgo }, status: 'completed' });
             const bothIds = buyerIds2.filter(id => sellerIds2.includes(id));
             return await User.find({ id: { $in: bothIds } }, { id: 1, email: 1 });


### PR DESCRIPTION
Problem: The function used 'Order.distinct()' but Order model is not defined. The codebase uses BuyOrder and SellOrder models instead.

Error: ReferenceError: Order is not defined
  at getTargetUsersByGroup (server.js:20735:31)

This occurred in two places:
1. Line 20725: Case 'buyers_30d' - getting users who made purchases
2. Line 20735: Case 'both_30d' - getting users who both bought and sold

Solution: Replace 'Order' with 'BuyOrder' in both locations since:
- BuyOrder tracks all purchases
- SellOrder/Withdrawal tracks all sales
- Using BuyOrder for purchase filtering is correct

This fixes the broadcast targeting system for:
- Buyers (Past 30 Days)
- Buyers & Sellers (Past 30 Days)