### PR TITLE
Fix zero users in broadcast targeting - use correct date field

### DIFF
--- a/server.js
+++ b/server.js
@@ -20722,18 +20722,18 @@ async function getTargetUsersByGroup(targetGroup) {
 
         case 'buyers_30d':
             // Users who made purchases in past 30 days
-            const buyerIds = await BuyOrder.distinct('telegramId', { createdAt: { $gte: thirtyDaysAgo }, status: 'completed' });
+            const buyerIds = await BuyOrder.distinct('telegramId', { dateCreated: { $gte: thirtyDaysAgo }, status: 'completed' });
             return await User.find({ id: { $in: buyerIds } }, { id: 1, email: 1 });
 
         case 'sellers_30d':
             // Users who made sales in past 30 days
-            const sellerIds = await SellOrder.distinct('telegramId', { createdAt: { $gte: thirtyDaysAgo }, status: 'completed' });
+            const sellerIds = await SellOrder.distinct('telegramId', { dateCreated: { $gte: thirtyDaysAgo }, status: 'completed' });
             return await User.find({ id: { $in: sellerIds } }, { id: 1, email: 1 });
 
         case 'both_30d':
             // Users who both bought and sold in past 30 days
-            const buyerIds2 = await BuyOrder.distinct('telegramId', { createdAt: { $gte: thirtyDaysAgo }, status: 'completed' });
-            const sellerIds2 = await SellOrder.distinct('telegramId', { createdAt: { $gte: thirtyDaysAgo }, status: 'completed' });
+            const buyerIds2 = await BuyOrder.distinct('telegramId', { dateCreated: { $gte: thirtyDaysAgo }, status: 'completed' });
+            const sellerIds2 = await SellOrder.distinct('telegramId', { dateCreated: { $gte: thirtyDaysAgo }, status: 'completed' });
             const bothIds = buyerIds2.filter(id => sellerIds2.includes(id));
             return await User.find({ id: { $in: bothIds } }, { id: 1, email: 1 });
 


### PR DESCRIPTION
Problem: Broadcast showed 'Will reach: 0 users' for all groups
Root cause: Using 'createdAt' field but BuyOrder and SellOrder use 'dateCreated'

Solution: Changed all date queries from 'createdAt' to 'dateCreated'
- buyers_30d: BuyOrder.distinct with dateCreated filter
- sellers_30d: SellOrder.distinct with dateCreated filter
- both_30d: Both models with dateCreated filter

This matches the actual schema field names:
✓ BuyOrder schema: dateCreated (line 1934)
✓ SellOrder schema: dateCreated (not createdAt)

Now broadcast will correctly count and target users from past 30 days.